### PR TITLE
Add support for failing promises in promise.all

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 clover.xml
 coveralls-upload.json
 phpunit.xml
+vendor/cghooks.lock
 vendor/

--- a/lib/AbstractPromise.php
+++ b/lib/AbstractPromise.php
@@ -111,4 +111,20 @@ abstract class AbstractPromise implements PromiseInterface
     {
         return $this->state == self::STATE_FULFILLED;
     }
+
+    /**
+     * @param mixed $error
+     * @return string
+     */
+    protected static function stringifyError($error): string
+    {
+        $formattedError = $error;
+        if ($error instanceof \Throwable) {
+            $formattedError = $error->getMessage();
+        } elseif (!is_string($error)) {
+            $formattedError = var_export($error, true);
+        }
+
+        return $formattedError;
+    }
 }

--- a/lib/AbstractPromise.php
+++ b/lib/AbstractPromise.php
@@ -111,20 +111,4 @@ abstract class AbstractPromise implements PromiseInterface
     {
         return $this->state == self::STATE_FULFILLED;
     }
-
-    /**
-     * @param mixed $error
-     * @return string
-     */
-    protected static function stringifyError($error): string
-    {
-        $formattedError = $error;
-        if ($error instanceof \Throwable) {
-            $formattedError = $error->getMessage();
-        } elseif (!is_string($error)) {
-            $formattedError = var_export($error, true);
-        }
-
-        return $formattedError;
-    }
 }

--- a/lib/ExtSwoolePromise.php
+++ b/lib/ExtSwoolePromise.php
@@ -123,7 +123,6 @@ final class ExtSwoolePromise extends AbstractPromise
                     $channel->push(true);
                     if ($firstError === null) {
                         $firstError = self::stringifyError($error);
-                        ;
                     }
                 });
                 $key++;

--- a/lib/ExtSwoolePromise.php
+++ b/lib/ExtSwoolePromise.php
@@ -122,7 +122,7 @@ final class ExtSwoolePromise extends AbstractPromise
                 }, function ($error) use ($channel, &$firstError) {
                     $channel->push(true);
                     if ($firstError === null) {
-                        $firstError = self::stringifyError($error);
+                        $firstError = $error;
                     }
                 });
                 $key++;

--- a/lib/ExtSwoolePromise.php
+++ b/lib/ExtSwoolePromise.php
@@ -101,11 +101,13 @@ final class ExtSwoolePromise extends AbstractPromise
      */
     public static function all(iterable $promises): PromiseInterface
     {
-        return self::create(function (callable $resolve) use ($promises) {
-            $ticks   = count($promises);
-            $channel = new Channel($ticks);
-            $result  = new ArrayCollection();
-            $key     = 0;
+        return self::create(function (callable $resolve, callable $reject) use ($promises) {
+            $ticks = count($promises);
+
+            $firstError = null;
+            $channel    = new Channel($ticks);
+            $result     = new ArrayCollection();
+            $key        = 0;
             foreach ($promises as $promise) {
                 if (!$promise instanceof ExtSwoolePromise) {
                     $channel->close();
@@ -117,6 +119,12 @@ final class ExtSwoolePromise extends AbstractPromise
                     $result->set($key, $value);
                     $channel->push(true);
                     return $value;
+                }, function ($error) use ($channel, &$firstError) {
+                    $channel->push(true);
+                    if ($firstError === null) {
+                        $firstError = self::stringifyError($error);
+                        ;
+                    }
                 });
                 $key++;
             }
@@ -124,6 +132,12 @@ final class ExtSwoolePromise extends AbstractPromise
                 $channel->pop();
             }
             $channel->close();
+
+            if ($firstError !== null) {
+                $reject($firstError);
+                return;
+            }
+
             $resolve($result);
         });
     }

--- a/lib/Promise.php
+++ b/lib/Promise.php
@@ -76,9 +76,11 @@ final class Promise extends AbstractPromise implements WaitInterface
      */
     public static function all(iterable $promises): PromiseInterface
     {
-        return self::create(function (callable $resolve) use ($promises) {
-            $result = new ArrayCollection();
-            $key    = 0;
+        return self::create(function (callable $resolve, callable $reject) use ($promises) {
+            $result     = new ArrayCollection();
+            $key        = 0;
+            $firstError = null;
+
             foreach ($promises as $promise) {
                 if (!$promise instanceof Promise) {
                     throw new Exception\RuntimeException('Supported only Streamcommon\Promise\Promise instance');
@@ -86,10 +88,22 @@ final class Promise extends AbstractPromise implements WaitInterface
                 $promise->then(function ($value) use ($key, $result) {
                     $result->set($key, $value);
                     return $value;
+                }, function ($error) use (&$firstError) {
+                    if ($firstError !== null) {
+                        return;
+                    }
+
+                    $firstError = self::stringifyError($error);
                 });
                 $promise->wait();
                 $key++;
             }
+
+            if ($firstError !== null) {
+                $reject($firstError);
+                return;
+            }
+
             $resolve($result);
         });
     }

--- a/lib/Promise.php
+++ b/lib/Promise.php
@@ -93,7 +93,7 @@ final class Promise extends AbstractPromise implements WaitInterface
                         return;
                     }
 
-                    $firstError = self::stringifyError($error);
+                    $firstError = $error;
                 });
                 $promise->wait();
                 $key++;

--- a/test/ExtSwoolePromiseTest.php
+++ b/test/ExtSwoolePromiseTest.php
@@ -269,43 +269,6 @@ class ExtSwoolePromiseTest extends TestCase
     }
 
     /**
-     * Test promise all with a throwable failure which should be converted to a string
-     *
-     * @return void
-     */
-    public function testPromiseThrowableFailuresAreConverted(): void
-    {
-        $promise = ExtSwoolePromise::create(function (callable $resolve, callable $reject) {
-            $reject(new RuntimeException('some exceptional message'));
-        });
-
-        /** @var ExtSwoolePromise $promise */
-        $promise = ExtSwoolePromise::all([$promise]);
-        $promise->then(null, function ($value) {
-            $this->assertEquals('some exceptional message', $value);
-        });
-    }
-
-
-    /**
-     * Test promise all with non stringable  which should be converted to a string
-     *
-     * @return void
-     */
-    public function testPromiseNonStringableValuesAreConverted(): void
-    {
-        $promise = ExtSwoolePromise::create(function (callable $resolve, callable $reject) {
-            $reject(['some exceptional message']);
-        });
-
-        /** @var ExtSwoolePromise $promise */
-        $promise = ExtSwoolePromise::all([$promise]);
-        $promise->then(null, function ($value) {
-            $this->assertEquals(var_export('some exceptional message', true), $value);
-        });
-    }
-
-    /**
      * Test promise all first error received is the error returned
      *
      * @return void

--- a/test/ExtSwoolePromiseTest.php
+++ b/test/ExtSwoolePromiseTest.php
@@ -295,7 +295,7 @@ class ExtSwoolePromiseTest extends TestCase
     public function testPromiseNonStringableValuesAreConverted(): void
     {
         $promise = ExtSwoolePromise::create(function (callable $resolve, callable $reject) {
-            $reject(new RuntimeException(['some exceptional message']));
+            $reject(['some exceptional message']);
         });
 
         /** @var ExtSwoolePromise $promise */

--- a/test/ExtSwoolePromiseTest.php
+++ b/test/ExtSwoolePromiseTest.php
@@ -286,6 +286,25 @@ class ExtSwoolePromiseTest extends TestCase
         });
     }
 
+
+    /**
+     * Test promise all with non stringable  which should be converted to a string
+     *
+     * @return void
+     */
+    public function testPromiseNonStringableValuesAreConverted(): void
+    {
+        $promise = ExtSwoolePromise::create(function (callable $resolve, callable $reject) {
+            $reject(new RuntimeException(['some exceptional message']));
+        });
+
+        /** @var ExtSwoolePromise $promise */
+        $promise = ExtSwoolePromise::all([$promise]);
+        $promise->then(null, function ($value) {
+            $this->assertEquals(var_export('some exceptional message', true), $value);
+        });
+    }
+
     /**
      * Test promise all first error received is the error returned
      *

--- a/test/PromiseTest.php
+++ b/test/PromiseTest.php
@@ -255,6 +255,76 @@ class PromiseTest extends TestCase
     }
 
     /**
+     * Test promise all with failures
+     *
+     * @return void
+     */
+    public function testPromiseAnyFailure(): void
+    {
+        $promise1 = Promise::create(function (callable $resolve) {
+            $resolve(41);
+        });
+        $promise2 = Promise::create(function (callable $resolve, callable $reject) {
+            $reject('A incidental error has occurred');
+        });
+
+        /** @var Promise $promise */
+        $promise = Promise::all([$promise1, $promise2]);
+        $promise->then(null, function ($value) {
+            $this->assertEquals('A incidental error has occurred', $value);
+        });
+
+        $promise->wait();
+    }
+
+    /**
+     * Test promise all with a throwable failure which should be converted to a string
+     *
+     * @return void
+     */
+    public function testPromiseThrowableFailuresAreConverted(): void
+    {
+        $promise = Promise::create(function (callable $resolve, callable $reject) {
+            $reject(new RuntimeException('some exceptional message'));
+        });
+
+        /** @var Promise $promise */
+        $promise = Promise::all([$promise]);
+        $promise->then(null, function ($value) {
+            $this->assertEquals('some exceptional message', $value);
+        });
+
+        $promise->wait();
+    }
+
+    /**
+     * Test promise all first error received is the error returned
+     *
+     * @return void
+     */
+    public function testPromiseAllMultipleErrorsWillStillOnlyReturnFirstFailure()
+    {
+        $promise1 = Promise::create(function (callable $resolve, callable $reject) {
+            $reject(new RuntimeException('some failing message'));
+        });
+
+        $promise2 = Promise::create(function (callable $resolve, callable $reject) {
+            $reject(new RuntimeException('this message is also failing but should not appear'));
+        });
+
+        /** @var Promise $promise */
+        $promise = Promise::all([$promise1, $promise2]);
+        $promise->then(null, function ($value) {
+            $this->assertEquals('some failing message', $value);
+        });
+
+        $promise->wait();
+    }
+
+
+
+
+    /**
      * Test promise catch
      *
      *

--- a/test/PromiseTest.php
+++ b/test/PromiseTest.php
@@ -298,6 +298,27 @@ class PromiseTest extends TestCase
     }
 
     /**
+     * Test promise all with non stringable  which should be converted to a string
+     *
+     * @return void
+     */
+    public function testPromiseNonStringableValuesAreConverted(): void
+    {
+        $promise = Promise::create(function (callable $resolve, callable $reject) {
+            $reject(new RuntimeException(['some exceptional message']));
+        });
+
+        /** @var Promise $promise */
+        $promise = Promise::all([$promise]);
+        $promise->then(null, function ($value) {
+            $this->assertEquals(var_export('some exceptional message', true), $value);
+        });
+
+        $promise->wait();
+    }
+
+
+    /**
      * Test promise all first error received is the error returned
      *
      * @return void

--- a/test/PromiseTest.php
+++ b/test/PromiseTest.php
@@ -278,47 +278,6 @@ class PromiseTest extends TestCase
     }
 
     /**
-     * Test promise all with a throwable failure which should be converted to a string
-     *
-     * @return void
-     */
-    public function testPromiseThrowableFailuresAreConverted(): void
-    {
-        $promise = Promise::create(function (callable $resolve, callable $reject) {
-            $reject(new RuntimeException('some exceptional message'));
-        });
-
-        /** @var Promise $promise */
-        $promise = Promise::all([$promise]);
-        $promise->then(null, function ($value) {
-            $this->assertEquals('some exceptional message', $value);
-        });
-
-        $promise->wait();
-    }
-
-    /**
-     * Test promise all with non stringable  which should be converted to a string
-     *
-     * @return void
-     */
-    public function testPromiseNonStringableValuesAreConverted(): void
-    {
-        $promise = Promise::create(function (callable $resolve, callable $reject) {
-            $reject(['some exceptional message']);
-        });
-
-        /** @var Promise $promise */
-        $promise = Promise::all([$promise]);
-        $promise->then(null, function ($value) {
-            $this->assertEquals(var_export('some exceptional message', true), $value);
-        });
-
-        $promise->wait();
-    }
-
-
-    /**
      * Test promise all first error received is the error returned
      *
      * @return void

--- a/test/PromiseTest.php
+++ b/test/PromiseTest.php
@@ -305,7 +305,7 @@ class PromiseTest extends TestCase
     public function testPromiseNonStringableValuesAreConverted(): void
     {
         $promise = Promise::create(function (callable $resolve, callable $reject) {
-            $reject(new RuntimeException(['some exceptional message']));
+            $reject(['some exceptional message']);
         });
 
         /** @var Promise $promise */


### PR DESCRIPTION
First of all,thanks for bringing true promises to php. I noticed however that there's no support for failing promises in promise.all, something which i need. 

From the MDN Web docs
`The Promise.all() method returns a single Promise that fulfills when all of the promises passed as an iterable have been fulfilled, the iterable contains no promises, or the iterable contains promises that have been fulfilled and non-promises that have been returned. It rejects with the reason of the first promise that rejects or with the error caught by the first argument, if that argument has caught an error inside it using try/catch/throw blocks.`